### PR TITLE
use detect-node module due to unreliability of global window variable in some cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "author": "Tyler Brock",
   "license": "MIT",
   "dependencies": {
+    "detect-node": "^2.0.3",
     "parse": "^1.9.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "Tyler Brock",
   "license": "MIT",
   "dependencies": {
-    "detect-node": "^2.0.3",
+    "detect-is-node": "^1.0.3",
     "parse": "^1.9.2"
   }
 }

--- a/parse-shim.js
+++ b/parse-shim.js
@@ -1,7 +1,10 @@
 // This is a shim that loads the correct version of parse for a given environment
+
+const isNode = require('detect-node')
+
 if ( typeof Parse !== 'undefined' && Parse ) {
   module.exports = Parse;
-} else if (typeof window === 'undefined') {
+} else if (isNode) {
   module.exports = require('parse/node');
 } else {
   module.exports = require('parse');

--- a/parse-shim.js
+++ b/parse-shim.js
@@ -1,6 +1,6 @@
 // This is a shim that loads the correct version of parse for a given environment
 
-const isNode = require('detect-node')
+const isNode = require('detect-is-node')
 
 if ( typeof Parse !== 'undefined' && Parse ) {
   module.exports = Parse;


### PR DESCRIPTION
Detect whether running in node or browser using the ‘detect-is-node’ module, which accounts for the window global being declared through JS DOM.
